### PR TITLE
refactor: centralize shared layout and logic

### DIFF
--- a/public/color-template.html
+++ b/public/color-template.html
@@ -1,105 +1,15 @@
 <!DOCTYPE html>
 <head>
-    <link rel="stylesheet" href="all-pages.css">
+    <script src="common.js"></script>
 </head>
 <div id="colorsContainer">
     <div id="colorA" class="color">
         <div id="colorSelectorRowA">
-            <select class="selectedColor">
-                <option value="Select color">Select color</option>
-                <option value="AXL">AXL</option>
-                <option value="BL">BL</option>
-                <option value="CL">CL</option>
-                <option value="DL">DL</option>
-                <option value="EL">EL</option>
-                <option value="FL">FL</option>
-                <option value="IL">IL</option>
-                <option value="JL">JL</option>
-                <option value="KXL">KXL</option>
-                <option value="LL">LL</option>
-                <option value="RL">RL</option>
-                <option value="RUL">RUL</option>
-                <option value="TL">TL</option>
-                <option value="VL">VL</option>
-                <option value="VUL">VUL</option>
-                <option value="YL">YL</option>
-            </select>
-            <select class="selectedColor">
-                <option value="Select color">Select color</option>
-                <option value="AXL">AXL</option>
-                <option value="BL">BL</option>
-                <option value="CL">CL</option>
-                <option value="DL">DL</option>
-                <option value="EL">EL</option>
-                <option value="FL">FL</option>
-                <option value="IL">IL</option>
-                <option value="JL">JL</option>
-                <option value="KXL">KXL</option>
-                <option value="LL">LL</option>
-                <option value="RL">RL</option>
-                <option value="RUL">RUL</option>
-                <option value="TL">TL</option>
-                <option value="VL">VL</option>
-                <option value="VUL">VUL</option>
-                <option value="YL">YL</option>
-            </select>
-            <select class="selectedColor">
-                <option value="Select color">Select color</option>
-                <option value="AXL">AXL</option>
-                <option value="BL">BL</option>
-                <option value="CL">CL</option>
-                <option value="DL">DL</option>
-                <option value="EL">EL</option>
-                <option value="FL">FL</option>
-                <option value="IL">IL</option>
-                <option value="JL">JL</option>
-                <option value="KXL">KXL</option>
-                <option value="LL">LL</option>
-                <option value="RL">RL</option>
-                <option value="RUL">RUL</option>
-                <option value="TL">TL</option>
-                <option value="VL">VL</option>
-                <option value="VUL">VUL</option>
-                <option value="YL">YL</option>
-            </select>
-            <select class="selectedColor">
-                <option value="Select color">Select color</option>
-                <option value="AXL">AXL</option>
-                <option value="BL">BL</option>
-                <option value="CL">CL</option>
-                <option value="DL">DL</option>
-                <option value="EL">EL</option>
-                <option value="FL">FL</option>
-                <option value="IL">IL</option>
-                <option value="JL">JL</option>
-                <option value="KXL">KXL</option>
-                <option value="LL">LL</option>
-                <option value="RL">RL</option>
-                <option value="RUL">RUL</option>
-                <option value="TL">TL</option>
-                <option value="VL">VL</option>
-                <option value="VUL">VUL</option>
-                <option value="YL">YL</option>
-            </select>
-            <select class="selectedColor">
-                <option value="Select color">Select color</option>
-                <option value="AXL">AXL</option>
-                <option value="BL">BL</option>
-                <option value="CL">CL</option>
-                <option value="DL">DL</option>
-                <option value="EL">EL</option>
-                <option value="FL">FL</option>
-                <option value="IL">IL</option>
-                <option value="JL">JL</option>
-                <option value="KXL">KXL</option>
-                <option value="LL">LL</option>
-                <option value="RL">RL</option>
-                <option value="RUL">RUL</option>
-                <option value="TL">TL</option>
-                <option value="VL">VL</option>
-                <option value="VUL">VUL</option>
-                <option value="YL">YL</option>
-            </select>
+            <select class="selectedColor"></select>
+            <select class="selectedColor"></select>
+            <select class="selectedColor"></select>
+            <select class="selectedColor"></select>
+            <select class="selectedColor"></select>
         </div>
         <div id="ouncesRowA">
                 <input class="ounces" placeholder="Ounces" type="number" min="0" max="100">
@@ -117,21 +27,3 @@
         </div>
     </div>
 </div>
-
-<script>
-    function createFormulas(container) { //TODO change this to the new list of colorants
-        let formulas = []; //start up the list
-        let table = document.querySelector(container);
-        for (let i = 0; i < table.children.length; i++) { //Iterates through each table
-            let color = {}; //start up the dictionary
-            for (let j = 0; j < 5; j++) { //Iterates through each column. i is the table, j is the column
-                let colorant = table.children[i].children[0].children[j].value;
-                let ounces = + table.children[i].children[1].children[j].value;
-                let drops = + table.children[i].children[2].children[j].value;
-                color[colorant] = [ounces, drops];
-            }
-            formulas.push(color);
-        }
-        return formulas;
-    }
-</script>

--- a/public/combiner.html
+++ b/public/combiner.html
@@ -1,127 +1,19 @@
 <!DOCTYPE html>
 <html>
-
 <head>
     <title>Paint Tools Alpha</title>
-    <link rel="stylesheet" href="all-pages.css">
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-    <!-- This section is for PWA stuff -->
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <meta name="description" content="Tools for the paint desk.">
-    <meta name="theme-color" content="#888888">
-    <link rel="manifest" href="manifest.json">
-    <script>
-        if ("serviceWorker" in navigator) {
-            window.addEventListener("load", function () {
-                navigator.serviceWorker.register("sw.js");
-            });
-        }
-    </script>
-    <!-- End PWA stuff -->
+    <script src="common.js"></script>
 </head>
-
 <body>
     <h1 id="page-title">Color Combiner</h1>
     <div id="colorsContainer">
         <div id="colorA" class="color">
             <div id="colorSelectorRowA">
-                <select class="selectedColor">
-                    <option value="Select color">Select color</option>
-                    <option value="AXL">AXL</option>
-                    <option value="BL">BL</option>
-                    <option value="CL">CL</option>
-                    <option value="DL">DL</option>
-                    <option value="EL">EL</option>
-                    <option value="FL">FL</option>
-                    <option value="IL">IL</option>
-                    <option value="JL">JL</option>
-                    <option value="KXL">KXL</option>
-                    <option value="LL">LL</option>
-                    <option value="RL">RL</option>
-                    <option value="RUL">RUL</option>
-                    <option value="TL">TL</option>
-                    <option value="VL">VL</option>
-                    <option value="VUL">VUL</option>
-                    <option value="YL">YL</option>
-                </select>
-                <select class="selectedColor">
-                    <option value="Select color">Select color</option>
-                    <option value="AXL">AXL</option>
-                    <option value="BL">BL</option>
-                    <option value="CL">CL</option>
-                    <option value="DL">DL</option>
-                    <option value="EL">EL</option>
-                    <option value="FL">FL</option>
-                    <option value="IL">IL</option>
-                    <option value="JL">JL</option>
-                    <option value="KXL">KXL</option>
-                    <option value="LL">LL</option>
-                    <option value="RL">RL</option>
-                    <option value="RUL">RUL</option>
-                    <option value="TL">TL</option>
-                    <option value="VL">VL</option>
-                    <option value="VUL">VUL</option>
-                    <option value="YL">YL</option>
-                </select>
-                <select class="selectedColor">
-                    <option value="Select color">Select color</option>
-                    <option value="AXL">AXL</option>
-                    <option value="BL">BL</option>
-                    <option value="CL">CL</option>
-                    <option value="DL">DL</option>
-                    <option value="EL">EL</option>
-                    <option value="FL">FL</option>
-                    <option value="IL">IL</option>
-                    <option value="JL">JL</option>
-                    <option value="KXL">KXL</option>
-                    <option value="LL">LL</option>
-                    <option value="RL">RL</option>
-                    <option value="RUL">RUL</option>
-                    <option value="TL">TL</option>
-                    <option value="VL">VL</option>
-                    <option value="VUL">VUL</option>
-                    <option value="YL">YL</option>
-                </select>
-                <select class="selectedColor">
-                    <option value="Select color">Select color</option>
-                    <option value="AXL">AXL</option>
-                    <option value="BL">BL</option>
-                    <option value="CL">CL</option>
-                    <option value="DL">DL</option>
-                    <option value="EL">EL</option>
-                    <option value="FL">FL</option>
-                    <option value="IL">IL</option>
-                    <option value="JL">JL</option>
-                    <option value="KXL">KXL</option>
-                    <option value="LL">LL</option>
-                    <option value="RL">RL</option>
-                    <option value="RUL">RUL</option>
-                    <option value="TL">TL</option>
-                    <option value="VL">VL</option>
-                    <option value="VUL">VUL</option>
-                    <option value="YL">YL</option>
-                </select>
-                <select class="selectedColor">
-                    <option value="Select color">Select color</option>
-                    <option value="AXL">AXL</option>
-                    <option value="BL">BL</option>
-                    <option value="CL">CL</option>
-                    <option value="DL">DL</option>
-                    <option value="EL">EL</option>
-                    <option value="FL">FL</option>
-                    <option value="IL">IL</option>
-                    <option value="JL">JL</option>
-                    <option value="KXL">KXL</option>
-                    <option value="LL">LL</option>
-                    <option value="RL">RL</option>
-                    <option value="RUL">RUL</option>
-                    <option value="TL">TL</option>
-                    <option value="VL">VL</option>
-                    <option value="VUL">VUL</option>
-                    <option value="YL">YL</option>
-                </select>
+                <select class="selectedColor"></select>
+                <select class="selectedColor"></select>
+                <select class="selectedColor"></select>
+                <select class="selectedColor"></select>
+                <select class="selectedColor"></select>
             </div>
             <div id="ouncesRowA">
                 <input class="ounces" placeholder="Ounces" type="number" min="0" max="100">
@@ -140,101 +32,11 @@
         </div>
         <div id="colorB" class="color">
             <div id="colorSelectorRow">
-                <select class="selectedColor">
-                    <option value="Select color">Select color</option>
-                    <option value="AXL">AXL</option>
-                    <option value="BL">BL</option>
-                    <option value="CL">CL</option>
-                    <option value="DL">DL</option>
-                    <option value="EL">EL</option>
-                    <option value="FL">FL</option>
-                    <option value="IL">IL</option>
-                    <option value="JL">JL</option>
-                    <option value="KXL">KXL</option>
-                    <option value="LL">LL</option>
-                    <option value="RL">RL</option>
-                    <option value="RUL">RUL</option>
-                    <option value="TL">TL</option>
-                    <option value="VL">VL</option>
-                    <option value="VUL">VUL</option>
-                    <option value="YL">YL</option>
-                </select>
-                <select class="selectedColor">
-                    <option value="Select color">Select color</option>
-                    <option value="AXL">AXL</option>
-                    <option value="BL">BL</option>
-                    <option value="CL">CL</option>
-                    <option value="DL">DL</option>
-                    <option value="EL">EL</option>
-                    <option value="FL">FL</option>
-                    <option value="IL">IL</option>
-                    <option value="JL">JL</option>
-                    <option value="KXL">KXL</option>
-                    <option value="LL">LL</option>
-                    <option value="RL">RL</option>
-                    <option value="RUL">RUL</option>
-                    <option value="TL">TL</option>
-                    <option value="VL">VL</option>
-                    <option value="VUL">VUL</option>
-                    <option value="YL">YL</option>
-                </select>
-                <select class="selectedColor">
-                    <option value="Select color">Select color</option>
-                    <option value="AXL">AXL</option>
-                    <option value="BL">BL</option>
-                    <option value="CL">CL</option>
-                    <option value="DL">DL</option>
-                    <option value="EL">EL</option>
-                    <option value="FL">FL</option>
-                    <option value="IL">IL</option>
-                    <option value="JL">JL</option>
-                    <option value="KXL">KXL</option>
-                    <option value="LL">LL</option>
-                    <option value="RL">RL</option>
-                    <option value="RUL">RUL</option>
-                    <option value="TL">TL</option>
-                    <option value="VL">VL</option>
-                    <option value="VUL">VUL</option>
-                    <option value="YL">YL</option>
-                </select>
-                <select class="selectedColor">
-                    <option value="Select color">Select color</option>
-                    <option value="AXL">AXL</option>
-                    <option value="BL">BL</option>
-                    <option value="CL">CL</option>
-                    <option value="DL">DL</option>
-                    <option value="EL">EL</option>
-                    <option value="FL">FL</option>
-                    <option value="IL">IL</option>
-                    <option value="JL">JL</option>
-                    <option value="KXL">KXL</option>
-                    <option value="LL">LL</option>
-                    <option value="RL">RL</option>
-                    <option value="RUL">RUL</option>
-                    <option value="TL">TL</option>
-                    <option value="VL">VL</option>
-                    <option value="VUL">VUL</option>
-                    <option value="YL">YL</option>
-                </select>
-                <select class="selectedColor">
-                    <option value="Select color">Select color</option>
-                    <option value="AXL">AXL</option>
-                    <option value="BL">BL</option>
-                    <option value="CL">CL</option>
-                    <option value="DL">DL</option>
-                    <option value="EL">EL</option>
-                    <option value="FL">FL</option>
-                    <option value="IL">IL</option>
-                    <option value="JL">JL</option>
-                    <option value="KXL">KXL</option>
-                    <option value="LL">LL</option>
-                    <option value="RL">RL</option>
-                    <option value="RUL">RUL</option>
-                    <option value="TL">TL</option>
-                    <option value="VL">VL</option>
-                    <option value="VUL">VUL</option>
-                    <option value="YL">YL</option>
-                </select>
+                <select class="selectedColor"></select>
+                <select class="selectedColor"></select>
+                <select class="selectedColor"></select>
+                <select class="selectedColor"></select>
+                <select class="selectedColor"></select>
             </div>
             <div id="ouncesRowB">
                 <input class="ounces" placeholder="Ounces" type="number" min="0" max="100">
@@ -253,115 +55,50 @@
         </div>
     </div>
 
-    <button id=combineButton>Combine</button>
+    <button id="combineButton">Combine</button>
     <h1>Results</h1>
     <div id="resultsArea">
         <table id="resultsTable">
-            <tr id="resultColorNames">
-            </tr>
-            <tr id=resultOunces>
-            </tr>
-            <tr id=resultDrops>
-            </tr>
+            <tr id="resultColorNames"></tr>
+            <tr id="resultOunces"></tr>
+            <tr id="resultDrops"></tr>
         </table>
-
     </div>
-</body>
-
-<!-- Navigation bar -->
-<nav>
-    <li>
-        <a href="scaler.html">Scale</a>
-    </li><li>
-        <a href="combiner.html" class="active">Combine</a>
-    </li><li>
-        <a href="resizer.html">Resize</a>
-    </li><li>
-        <a class="externalWebsite" href="https://encycolorpedia.com/">Encycolorpedia</a>
-    </li><li>
-        <a class="externalWebsite" href="https://www.easyrgb.com/en/match.php">EasyRGB</a>
-    </li>
-</nav>
-</html>
-
-<script>
-    function combineColors(colorA, colorB) {
-            //colorA and colorB are "dictionaries"
-            //colorA = {"KXL":[1,192], "LL":[0,192]}
+    <script>
+        function combineColors(colorA, colorB) {
             var newColor = {};
-            for (var color in colorA) { //color is the key, colorA[color] is the value
+            for (var color in colorA) {
                 let totalDropsDivideHalf = ((colorA[color][0] * 384) + colorA[color][1]) / 2;
                 let newOunces = Math.floor(totalDropsDivideHalf / 384);
                 let newDrops = Math.round((totalDropsDivideHalf % 384) * 2) / 2;
-                newColor[color] = [newOunces, newDrops]
+                newColor[color] = [newOunces, newDrops];
             }
             for (var color in colorB) {
                 let totalDropsDivideHalf = ((colorB[color][0] * 384) + colorB[color][1]) / 2;
                 let newOunces = Math.floor(totalDropsDivideHalf / 384);
                 let newDrops = Math.round((totalDropsDivideHalf % 384) * 2) / 2;
-                if (color in newColor) { //check if color already exists, if so add to it
+                if (color in newColor) {
                     newColor[color][0] += newOunces;
                     newColor[color][1] += newDrops;
-                    if (newColor[color][1] > 383) { // if adding colorB's drops caused it to go over an ounce, add the ounce and remove the drops
+                    if (newColor[color][1] > 383) {
                         newColor[color][0] += 1;
                         newColor[color][1] -= 384;
                     }
                 }
-                else { // Or make a new entry
+                else {
                     newColor[color] = [newOunces, newDrops];
                 }
             }
-            return newColor
+            return newColor;
         }
 
-    function createFormulas(container) { //TODO change this to the new list of colorants
-        let formulas = []; //start up the list
-        let table = document.querySelector(container);
-        for (let i = 0; i < table.children.length; i++) { //Iterates through each table
-            let color = {}; //start up the dictionary
-            for (let j = 0; j < 5; j++) { //Iterates through each column. i is the table, j is the column
-                let colorant = table.children[i].children[0].children[j].value;
-                let ounces = + table.children[i].children[1].children[j].value;
-                let drops = + table.children[i].children[2].children[j].value;
-                color[colorant] = [ounces, drops];
-            }
-            formulas.push(color);
+        const combineButton = document.querySelector("#combineButton");
+        combineButton.addEventListener("click", combineButtonClicked);
+        function combineButtonClicked() {
+            let colors = createFormulas("#colorsContainer");
+            let combinedColor = combineColors(colors[0], colors[1]);
+            displayResults(combinedColor);
         }
-        return formulas;
-    }
-
-    function displayResults(formula) {
-            let resultsTable = document.getElementById("resultsTable");
-            //clear results table
-            for (let i = 0; i < resultsTable.children.length; i++) {
-                for (let j = 0; j < resultsTable.children[i].children.length; j++) {
-                    resultsTable.children[i].children[j].innerHTML = "";
-                }
-            }
-            let resultColorNames = document.getElementById("resultColorNames");
-            let resultOunces = document.getElementById("resultOunces");
-            let resultDrops = document.getElementById("resultDrops");
-            for (const colorant in formula) {
-                if (colorant == "Select color") {
-                    continue;
-                }
-                let colorName = document.createElement("th");
-                colorName.innerHTML = colorant;
-                resultColorNames.appendChild(colorName);
-                let ounces = document.createElement("td");
-                ounces.innerHTML = formula[colorant][0];
-                resultOunces.appendChild(ounces);
-                let drops = document.createElement("td");
-                drops.innerHTML = formula[colorant][1];
-                resultDrops.appendChild(drops);
-            }
-        }
-
-    const combineButton = document.querySelector("#combineButton");
-    combineButton.addEventListener("click", combineButtonClicked);
-    function combineButtonClicked() {
-        let colors = createFormulas("#colorsContainer");
-        let combinedColor = combineColors(colors[0], colors[1]);
-        displayResults(combinedColor);
-    }
-</script>
+    </script>
+</body>
+</html>

--- a/public/common.js
+++ b/public/common.js
@@ -1,0 +1,139 @@
+(function(){
+  // List of color options
+  const COLORS = [
+    "AXL","BL","CL","DL","EL","FL","IL","JL","KXL","LL",
+    "RL","RUL","TL","VL","VUL","YL"
+  ];
+
+  // Add shared metadata, icons, stylesheet, and manifest
+  function addHeadElements() {
+    const head = document.head;
+    const tags = [
+      {tag:"link", rel:"stylesheet", href:"all-pages.css"},
+      {tag:"link", rel:"icon", type:"image/png", sizes:"32x32", href:"/favicon-32x32.png"},
+      {tag:"link", rel:"icon", type:"image/png", sizes:"16x16", href:"/favicon-16x16.png"},
+      {tag:"meta", name:"viewport", content:"width=device-width, initial-scale=1"},
+      {tag:"meta", httpEquiv:"X-UA-Compatible", content:"ie=edge"},
+      {tag:"meta", name:"description", content:"Tools for the paint desk."},
+      {tag:"meta", name:"theme-color", content:"#888888"},
+      {tag:"link", rel:"manifest", href:"manifest.json"}
+    ];
+    tags.forEach(info => {
+      const el = document.createElement(info.tag);
+      Object.keys(info).forEach(k => {
+        if(k !== 'tag') el.setAttribute(k, info[k]);
+      });
+      head.appendChild(el);
+    });
+  }
+
+  // Register service worker
+  function registerSW(){
+    if('serviceWorker' in navigator){
+      window.addEventListener('load', () => {
+        navigator.serviceWorker.register('sw.js');
+      });
+    }
+  }
+
+  // Build navigation bar
+  function buildNav(){
+    const nav = document.createElement('nav');
+    const links = [
+      {href:'scaler.html', text:'Scale'},
+      {href:'combiner.html', text:'Combine'},
+      {href:'resizer.html', text:'Resize'},
+      {href:'https://encycolorpedia.com/', text:'Encycolorpedia', external:true},
+      {href:'https://www.easyrgb.com/en/match.php', text:'EasyRGB', external:true}
+    ];
+    links.forEach(link => {
+      const li = document.createElement('li');
+      const a = document.createElement('a');
+      a.textContent = link.text;
+      a.href = link.href;
+      if(link.external) a.classList.add('externalWebsite');
+      const path = window.location.pathname.split('/').pop();
+      if(!link.external && path === link.href) a.classList.add('active');
+      li.appendChild(a);
+      nav.appendChild(li);
+    });
+    document.body.appendChild(nav);
+  }
+
+  // Populate color selectors
+  function populateColorSelectors(){
+    document.querySelectorAll('select.selectedColor').forEach(select => {
+      select.innerHTML = '';
+      const def = document.createElement('option');
+      def.value = 'Select color';
+      def.textContent = 'Select color';
+      select.appendChild(def);
+      COLORS.forEach(color => {
+        const opt = document.createElement('option');
+        opt.value = color;
+        opt.textContent = color;
+        select.appendChild(opt);
+      });
+    });
+  }
+
+  // Shared createFormulas function
+  function createFormulas(container, includePercentage=false){
+    const formulas = [];
+    const table = document.querySelector(container);
+    for(let i=0; i<table.children.length; i++){
+      const color = {};
+      const colorSelects = table.children[i].children[0].children;
+      for(let j=0; j<colorSelects.length; j++){
+        const colorant = colorSelects[j].value;
+        const ounces = +table.children[i].children[1].children[j].value;
+        const drops = +table.children[i].children[2].children[j].value;
+        if(includePercentage){
+          const percentage = +table.children[i].children[3].children[j].value;
+          color[colorant] = [ounces, drops, percentage];
+        } else {
+          color[colorant] = [ounces, drops];
+        }
+      }
+      formulas.push(color);
+    }
+    return formulas;
+  }
+
+  // Shared displayResults function
+  function displayResults(formula){
+    const resultsTable = document.getElementById('resultsTable');
+    for(let i=0; i<resultsTable.children.length; i++){
+      for(let j=0; j<resultsTable.children[i].children.length; j++){
+        resultsTable.children[i].children[j].innerHTML = '';
+      }
+    }
+    const resultColorNames = document.getElementById('resultColorNames');
+    const resultOunces = document.getElementById('resultOunces');
+    const resultDrops = document.getElementById('resultDrops');
+    for(const colorant in formula){
+      if(colorant === 'Select color') continue;
+      const colorName = document.createElement('th');
+      colorName.innerHTML = colorant;
+      resultColorNames.appendChild(colorName);
+      const ounces = document.createElement('td');
+      ounces.innerHTML = formula[colorant][0];
+      resultOunces.appendChild(ounces);
+      const drops = document.createElement('td');
+      drops.innerHTML = formula[colorant][1];
+      resultDrops.appendChild(drops);
+    }
+  }
+
+  // Expose functions globally
+  window.createFormulas = createFormulas;
+  window.displayResults = displayResults;
+
+  // initialize
+  addHeadElements();
+  registerSW();
+  document.addEventListener('DOMContentLoaded', () => {
+    populateColorSelectors();
+    buildNav();
+  });
+})();

--- a/public/resizer.html
+++ b/public/resizer.html
@@ -1,127 +1,19 @@
 <!DOCTYPE html>
 <html>
-
 <head>
     <title>Paint Tools Alpha</title>
-    <link rel="stylesheet" href="all-pages.css">
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-    <!-- This section is for PWA stuff -->
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <meta name="description" content="Tools for the paint desk.">
-    <meta name="theme-color" content="#888888">
-    <link rel="manifest" href="manifest.json">
-    <script>
-        if ("serviceWorker" in navigator) {
-            window.addEventListener("load", function () {
-                navigator.serviceWorker.register("sw.js");
-            });
-        }
-    </script>
-    <!-- End PWA stuff -->
+    <script src="common.js"></script>
 </head>
-
 <body>
     <h1 id="page-title">Formula Resizer</h1>
     <div id="colorsContainer">
         <div id="colorA" class="color">
             <div id="colorSelectorRowA">
-                <select class="selectedColor">
-                    <option value="Select color">Select color</option>
-                    <option value="AXL">AXL</option>
-                    <option value="BL">BL</option>
-                    <option value="CL">CL</option>
-                    <option value="DL">DL</option>
-                    <option value="EL">EL</option>
-                    <option value="FL">FL</option>
-                    <option value="IL">IL</option>
-                    <option value="JL">JL</option>
-                    <option value="KXL">KXL</option>
-                    <option value="LL">LL</option>
-                    <option value="RL">RL</option>
-                    <option value="RUL">RUL</option>
-                    <option value="TL">TL</option>
-                    <option value="VL">VL</option>
-                    <option value="VUL">VUL</option>
-                    <option value="YL">YL</option>
-                </select>
-                <select class="selectedColor">
-                    <option value="Select color">Select color</option>
-                    <option value="AXL">AXL</option>
-                    <option value="BL">BL</option>
-                    <option value="CL">CL</option>
-                    <option value="DL">DL</option>
-                    <option value="EL">EL</option>
-                    <option value="FL">FL</option>
-                    <option value="IL">IL</option>
-                    <option value="JL">JL</option>
-                    <option value="KXL">KXL</option>
-                    <option value="LL">LL</option>
-                    <option value="RL">RL</option>
-                    <option value="RUL">RUL</option>
-                    <option value="TL">TL</option>
-                    <option value="VL">VL</option>
-                    <option value="VUL">VUL</option>
-                    <option value="YL">YL</option>
-                </select>
-                <select class="selectedColor">
-                    <option value="Select color">Select color</option>
-                    <option value="AXL">AXL</option>
-                    <option value="BL">BL</option>
-                    <option value="CL">CL</option>
-                    <option value="DL">DL</option>
-                    <option value="EL">EL</option>
-                    <option value="FL">FL</option>
-                    <option value="IL">IL</option>
-                    <option value="JL">JL</option>
-                    <option value="KXL">KXL</option>
-                    <option value="LL">LL</option>
-                    <option value="RL">RL</option>
-                    <option value="RUL">RUL</option>
-                    <option value="TL">TL</option>
-                    <option value="VL">VL</option>
-                    <option value="VUL">VUL</option>
-                    <option value="YL">YL</option>
-                </select>
-                <select class="selectedColor">
-                    <option value="Select color">Select color</option>
-                    <option value="AXL">AXL</option>
-                    <option value="BL">BL</option>
-                    <option value="CL">CL</option>
-                    <option value="DL">DL</option>
-                    <option value="EL">EL</option>
-                    <option value="FL">FL</option>
-                    <option value="IL">IL</option>
-                    <option value="JL">JL</option>
-                    <option value="KXL">KXL</option>
-                    <option value="LL">LL</option>
-                    <option value="RL">RL</option>
-                    <option value="RUL">RUL</option>
-                    <option value="TL">TL</option>
-                    <option value="VL">VL</option>
-                    <option value="VUL">VUL</option>
-                    <option value="YL">YL</option>
-                </select>
-                <select class="selectedColor">
-                    <option value="Select color">Select color</option>
-                    <option value="AXL">AXL</option>
-                    <option value="BL">BL</option>
-                    <option value="CL">CL</option>
-                    <option value="DL">DL</option>
-                    <option value="EL">EL</option>
-                    <option value="FL">FL</option>
-                    <option value="IL">IL</option>
-                    <option value="JL">JL</option>
-                    <option value="KXL">KXL</option>
-                    <option value="LL">LL</option>
-                    <option value="RL">RL</option>
-                    <option value="RUL">RUL</option>
-                    <option value="TL">TL</option>
-                    <option value="VL">VL</option>
-                    <option value="VUL">VUL</option>
-                    <option value="YL">YL</option>
-                </select>
+                <select class="selectedColor"></select>
+                <select class="selectedColor"></select>
+                <select class="selectedColor"></select>
+                <select class="selectedColor"></select>
+                <select class="selectedColor"></select>
             </div>
             <div id="ouncesRowA">
                 <input class="ounces" placeholder="Ounces" type="number" min="0" max="100">
@@ -157,100 +49,36 @@
     <h1>Results</h1>
     <div id="resultsArea">
         <table id="resultsTable">
-            <tr id="resultColorNames">
-            </tr>
-            <tr id=resultOunces>
-            </tr>
-            <tr id=resultDrops>
-            </tr>
+            <tr id="resultColorNames"></tr>
+            <tr id="resultOunces"></tr>
+            <tr id="resultDrops"></tr>
         </table>
-
     </div>
-</body>
-
-<!-- Navigation bar -->
-<nav>
-    <li>
-        <a href="scaler.html">Scale</a>
-    </li><li>
-        <a href="combiner.html">Combine</a>
-    </li><li>
-        <a href="resizer.html" class="active">Resize</a>
-    </li><li>
-        <a class="externalWebsite" href="https://encycolorpedia.com/">Encycolorpedia</a>
-    </li><li>
-        <a class="externalWebsite" href="https://www.easyrgb.com/en/match.php">EasyRGB</a>
-    </li>
-</nav>
-</html>
-
-<script>
-    function createFormulas(container) {
-            let formulas = []; //start up the list
-            let table = document.querySelector(container);
-            for (let i = 0; i < table.children.length; i++) { //Iterates through each table
-                let color = {}; //start up the dictionary
-                for (let j = 0; j < 5; j++) { //Iterates through each column. i is the table, j is the column
-                    let colorant = table.children[i].children[0].children[j].value;
-                    let ounces = + table.children[i].children[1].children[j].value;
-                    let drops = + table.children[i].children[2].children[j].value;
-                    color[colorant] = [ounces, drops];
+    <script>
+        function resize(originalFormula, originalSize, newSize) {
+            let scaleFactor = newSize / originalSize;
+            let resizedFormula = {};
+            for (const colorant in originalFormula) {
+                if (colorant == "Select color") {
+                    continue;
                 }
-                formulas.push(color);
+                let totalDrops = (originalFormula[colorant][0] * 384) + originalFormula[colorant][1];
+                let resizedDrops = totalDrops * scaleFactor;
+                let resizedOunces = Math.floor(resizedDrops / 384);
+                let resizedDropsRemainder = Math.floor((resizedDrops % 384) * 100) / 100;
+                resizedFormula[colorant] = [resizedOunces, resizedDropsRemainder];
             }
-            return formulas;
+            return resizedFormula;
         }
 
-    function resize(originalFormula, originalSize, newSize) {
-        //color = {"KXL":[1,28]}
-        let scaleFactor = newSize / originalSize; //In ounces
-        let resizedFormula = {};
-        for (const colorant in originalFormula) {
-            if (colorant == "Select color") {
-                continue;
-            }
-            let totalDrops = (originalFormula[colorant][0] * 384) + originalFormula[colorant][1];
-            let resizedDrops = totalDrops * scaleFactor;
-            let resizedOunces = Math.floor(resizedDrops / 384);
-            let resizedDropsRemainder = Math.floor((resizedDrops % 384) * 100) / 100;
-            resizedFormula[colorant] = [resizedOunces, resizedDropsRemainder];
-        }
-        return resizedFormula;
-    }
-
-    function displayResults(formula) {
-        let resultsTable = document.getElementById("resultsTable");
-        //clear results table
-        for (let i = 0; i < resultsTable.children.length; i++) {
-            for (let j = 0; j < resultsTable.children[i].children.length; j++) {
-                resultsTable.children[i].children[j].innerHTML = "";
-            }
-        }
-        let resultColorNames = document.getElementById("resultColorNames");
-        let resultOunces = document.getElementById("resultOunces");
-        let resultDrops = document.getElementById("resultDrops");
-        for (const colorant in formula) {
-            if (colorant == "Select color") {
-                continue;
-            }
-            let colorName = document.createElement("th");
-            colorName.innerHTML = colorant;
-            resultColorNames.appendChild(colorName);
-            let ounces = document.createElement("td");
-            ounces.innerHTML = formula[colorant][0];
-            resultOunces.appendChild(ounces);
-            let drops = document.createElement("td");
-            drops.innerHTML = formula[colorant][1];
-            resultDrops.appendChild(drops);
-        }
-    }
-
-    const resizeButton = document.getElementById("resizeButton");
-    resizeButton.addEventListener("click", function () {
-        let originalFormula = createFormulas("#colorsContainer");
-        let originalSize = +document.getElementById("originalSize").value;
-        let newSize = +document.getElementById("newSize").value;
-        let resizedFormula = resize(originalFormula[0], originalSize, newSize);
-        displayResults(resizedFormula);
-    })
-</script>
+        const resizeButton = document.getElementById("resizeButton");
+        resizeButton.addEventListener("click", function () {
+            let originalFormula = createFormulas("#colorsContainer");
+            let originalSize = +document.getElementById("originalSize").value;
+            let newSize = +document.getElementById("newSize").value;
+            let resizedFormula = resize(originalFormula[0], originalSize, newSize);
+            displayResults(resizedFormula);
+        })
+    </script>
+</body>
+</html>

--- a/public/scaler.html
+++ b/public/scaler.html
@@ -1,127 +1,19 @@
 <!DOCTYPE html>
 <html>
-
 <head>
-        <title>Paint Tools Alpha</title>
-        <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-        <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-        <!-- This section is for PWA stuff -->
-        <link rel="stylesheet" href="all-pages.css">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <meta http-equiv="X-UA-Compatible" content="ie=edge">
-        <meta name="description" content="Tools for the paint desk.">
-        <meta name="theme-color" content="#888888">
-        <link rel="manifest" href="manifest.json">
-        <script>
-            if ("serviceWorker" in navigator) {
-                window.addEventListener("load", function() {
-                    navigator.serviceWorker.register("sw.js");
-                });
-            }
-        </script>
-        <!-- End PWA stuff -->
+    <title>Paint Tools Alpha</title>
+    <script src="common.js"></script>
 </head>
-
 <body>
     <h1 id="page-title">Color Scaler</h1>
     <div id="colorsContainer">
         <div id="colorA" class="color">
             <div id="colorSelectorRowA">
-                <select class="selectedColor">
-                    <option value="Select color">Select color</option>
-                    <option value="AXL">AXL</option>
-                    <option value="BL">BL</option>
-                    <option value="CL">CL</option>
-                    <option value="DL">DL</option>
-                    <option value="EL">EL</option>
-                    <option value="FL">FL</option>
-                    <option value="IL">IL</option>
-                    <option value="JL">JL</option>
-                    <option value="KXL">KXL</option>
-                    <option value="LL">LL</option>
-                    <option value="RL">RL</option>
-                    <option value="RUL">RUL</option>
-                    <option value="TL">TL</option>
-                    <option value="VL">VL</option>
-                    <option value="VUL">VUL</option>
-                    <option value="YL">YL</option>
-                </select>
-                <select class="selectedColor">
-                    <option value="Select color">Select color</option>
-                    <option value="AXL">AXL</option>
-                    <option value="BL">BL</option>
-                    <option value="CL">CL</option>
-                    <option value="DL">DL</option>
-                    <option value="EL">EL</option>
-                    <option value="FL">FL</option>
-                    <option value="IL">IL</option>
-                    <option value="JL">JL</option>
-                    <option value="KXL">KXL</option>
-                    <option value="LL">LL</option>
-                    <option value="RL">RL</option>
-                    <option value="RUL">RUL</option>
-                    <option value="TL">TL</option>
-                    <option value="VL">VL</option>
-                    <option value="VUL">VUL</option>
-                    <option value="YL">YL</option>
-                </select>
-                <select class="selectedColor">
-                    <option value="Select color">Select color</option>
-                    <option value="AXL">AXL</option>
-                    <option value="BL">BL</option>
-                    <option value="CL">CL</option>
-                    <option value="DL">DL</option>
-                    <option value="EL">EL</option>
-                    <option value="FL">FL</option>
-                    <option value="IL">IL</option>
-                    <option value="JL">JL</option>
-                    <option value="KXL">KXL</option>
-                    <option value="LL">LL</option>
-                    <option value="RL">RL</option>
-                    <option value="RUL">RUL</option>
-                    <option value="TL">TL</option>
-                    <option value="VL">VL</option>
-                    <option value="VUL">VUL</option>
-                    <option value="YL">YL</option>
-                </select>
-                <select class="selectedColor">
-                    <option value="Select color">Select color</option>
-                    <option value="AXL">AXL</option>
-                    <option value="BL">BL</option>
-                    <option value="CL">CL</option>
-                    <option value="DL">DL</option>
-                    <option value="EL">EL</option>
-                    <option value="FL">FL</option>
-                    <option value="IL">IL</option>
-                    <option value="JL">JL</option>
-                    <option value="KXL">KXL</option>
-                    <option value="LL">LL</option>
-                    <option value="RL">RL</option>
-                    <option value="RUL">RUL</option>
-                    <option value="TL">TL</option>
-                    <option value="VL">VL</option>
-                    <option value="VUL">VUL</option>
-                    <option value="YL">YL</option>
-                </select>
-                <select class="selectedColor">
-                    <option value="Select color">Select color</option>
-                    <option value="AXL">AXL</option>
-                    <option value="BL">BL</option>
-                    <option value="CL">CL</option>
-                    <option value="DL">DL</option>
-                    <option value="EL">EL</option>
-                    <option value="FL">FL</option>
-                    <option value="IL">IL</option>
-                    <option value="JL">JL</option>
-                    <option value="KXL">KXL</option>
-                    <option value="LL">LL</option>
-                    <option value="RL">RL</option>
-                    <option value="RUL">RUL</option>
-                    <option value="TL">TL</option>
-                    <option value="VL">VL</option>
-                    <option value="VUL">VUL</option>
-                    <option value="YL">YL</option>
-                </select>
+                <select class="selectedColor"></select>
+                <select class="selectedColor"></select>
+                <select class="selectedColor"></select>
+                <select class="selectedColor"></select>
+                <select class="selectedColor"></select>
             </div>
             <div id="ouncesRowA">
                 <input class="ounces" placeholder="Ounces" type="number" min="0" max="100">
@@ -143,7 +35,6 @@
                 <input class="percentage" placeholder="Percentage" type="number" min="-1000" max="1000">
                 <input class="percentage" placeholder="Percentage" type="number" min="-1000" max="1000">
                 <input class="percentage" placeholder="Percentage" type="number" min="-1000" max="1000">
-
             </div>
         </div>
     </div>
@@ -151,98 +42,29 @@
     <h1>Results</h1>
     <div id="resultsArea">
         <table id="resultsTable">
-            <tr id="resultColorNames">
-            </tr>
-            <tr id=resultOunces>
-            </tr>
-            <tr id=resultDrops>
-            </tr>
+            <tr id="resultColorNames"></tr>
+            <tr id="resultOunces"></tr>
+            <tr id="resultDrops"></tr>
         </table>
-
     </div>
+    <script>
+        const scaleButton = document.querySelector("#scaleButton");
+        scaleButton.addEventListener("click", scale);
+
+        function scale() {
+            const formula = createFormulas("#colorsContainer", true)[0];
+            const scaledFormula = {};
+            for (const colorant in formula) {
+                if (colorant == "Select color") {
+                    continue;
+                }
+                let totalDrops = ((formula[colorant][0] * 384) + formula[colorant][1]) * (formula[colorant][2] / 100);
+                let ounces = Math.floor(totalDrops / 384);
+                let drops = Math.floor((totalDrops % 384) * 100) / 100;
+                scaledFormula[colorant] = [ounces, drops];
+            };
+            displayResults(scaledFormula);
+        }
+    </script>
 </body>
-
-<!-- Navigation bar -->
-<nav>
-    <li>
-        <a href="scaler.html" class="active">Scale</a>
-    </li><li>
-        <a href="combiner.html">Combine</a>
-    </li><li>
-        <a href="resizer.html">Resize</a>
-    </li><li>
-        <a class="externalWebsite" href="https://encycolorpedia.com/">Encycolorpedia</a>
-    </li><li>
-        <a class="externalWebsite" href="https://www.easyrgb.com/en/match.php">EasyRGB</a>
-    </li>
-</nav>
 </html>
-
-<script>
-    //Adds event listeners for the two buttons
-    const scaleButton = document.querySelector("#scaleButton");
-    scaleButton.addEventListener("click", scale);
-    //Gets our layoutcontainer for adding rows
-    const colorContainer = document.querySelector("#colorA");
-
-    function createFormulas(container) {
-        let formulas = []; //start up the list
-        let table = document.querySelector(container);
-        for (let i = 0; i < table.children.length; i++) { //Iterates through each table
-            let color = {}; //start up the dictionary
-            for (let j = 0; j < 5; j++) { //Iterates through each column. i is the table, j is the column
-                let colorant = table.children[i].children[0].children[j].value;
-                let ounces = + table.children[i].children[1].children[j].value;
-                let drops = + table.children[i].children[2].children[j].value;
-                //specific for scaler
-                let percentage = + table.children[i].children[3].children[j].value;
-                color[colorant] = [ounces, drops, percentage];
-            }
-            formulas.push(color);
-        }
-        return formulas;
-    }
-
-    function scale() {
-        formula = createFormulas("#colorsContainer")[0];
-        let scaledFormula = {};
-        for (const colorant in formula) {
-            if (colorant == "Select color") {
-                continue;
-            }
-            let totalDrops = ((formula[colorant][0] * 384) + formula[colorant][1]) * (formula[colorant][2] / 100)
-            let ounces = Math.floor(totalDrops / 384);
-            let drops = Math.floor((totalDrops % 384) * 100) / 100;
-            scaledFormula[colorant] = [ounces, drops];
-        };
-        displayResults(scaledFormula)
-    }
-
-    function displayResults(formula) {
-        let resultsTable = document.getElementById("resultsTable");
-        //clear results table
-        for (let i = 0; i < resultsTable.children.length; i++) {
-            for (let j = 0; j < resultsTable.children[i].children.length; j++) {
-                resultsTable.children[i].children[j].innerHTML = "";
-            }
-        }
-        let resultColorNames = document.getElementById("resultColorNames");
-        let resultOunces = document.getElementById("resultOunces");
-        let resultDrops = document.getElementById("resultDrops");
-        for (const colorant in formula) {
-            if (colorant == "Select color") {
-                continue;
-            }
-            let colorName = document.createElement("th");
-            colorName.innerHTML = colorant;
-            resultColorNames.appendChild(colorName);
-            let ounces = document.createElement("td");
-            ounces.innerHTML = formula[colorant][0];
-            resultOunces.appendChild(ounces);
-            let drops = document.createElement("td");
-            drops.innerHTML = formula[colorant][1];
-            resultDrops.appendChild(drops);
-        }
-    }
-
-</script>

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,6 +2,7 @@ const version = "0.1.1"
 
 const assets = [
     "/all-pages.css",
+    "/common.js",
     "/scaler.html",
     "/combiner.html",
     "/resizer.html",


### PR DESCRIPTION
## Summary
- add common.js to inject shared meta tags, service worker registration, navigation bar, color options, and shared helper functions
- simplify combiner, scaler, resizer, and color template pages to rely on common.js instead of duplicating markup and logic
- cache new common.js in service worker

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688d717183c083248670604aac4455d8