### PR TITLE
SPA entry point with Home Depot theme, left sidebar, and responsive layout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 PaintTools is a client-side Progressive Web App (PWA) for paint color calculations. It has no build system, no dependencies, and no test framework — it is vanilla HTML/CSS/JavaScript deployed directly to Firebase Hosting.
 
+The primary entry point is `public/index.html`, a single-page app where all four tools load at once and tab-switching shows/hides views with CSS. The four individual `*.html` pages (scaler, combiner, resizer, differ) remain for backward compatibility but are no longer the canonical entry point.
+
 ## Deployment
 
 There is no build step. The `public/` directory is the deployable artifact.
@@ -16,13 +18,19 @@ There is no build step. The `public/` directory is the deployable artifact.
 
 ## Architecture
 
+### SPA entry point (`public/index.html`)
+
+Contains all four tool views as `<section class="view">` elements shown/hides via the `.active` CSS class. A left sidebar `<div id="sidebar">` contains a `<nav>` with `data-view` links. Hash-based routing (`#scaler`, `#combiner`, etc.) is handled by `showView()` and `hashchange` in the page's inline `<script>`. All four tools' event listeners are wired in one `DOMContentLoaded` handler. Each view uses prefixed element IDs (`scaler-resultColorNames`, `combiner-resultsTable`, etc.) to avoid collisions. A `makeDisplay(namesEl, ouncesEl, dropsEl)` factory produces per-view result renderers.
+
+On mobile (≤ 640 px) the sidebar becomes a fixed bottom tab bar via a media query; external links are hidden at that breakpoint.
+
 ### Shared initialization (`public/common.js`)
 
 All pages load `common.js` as their first `<script>` tag. It runs as an IIFE and:
 
-1. Injects head metadata, stylesheet, icons, and PWA manifest links via `addHeadElements()`
+1. Injects head metadata, stylesheet, icons, and PWA manifest links via `addHeadElements()` — skips if `<link href="all-pages.css">` is already present (as it is in `index.html`)
 2. Registers the service worker for offline support
-3. On `DOMContentLoaded`: populates all `<select class="selectedColor">` dropdowns from the `COLORS` array and builds the bottom nav bar
+3. On `DOMContentLoaded`: populates all `<select class="selectedColor">` dropdowns from the `COLORS` array; calls `buildNav()` (skips if a `<nav>` already exists) for the legacy individual pages; calls `buildPasteInputs()` which targets both `#colorsContainer .color` and `.colorsContainer .color`
 
 Two functions are exposed as globals for page scripts to call:
 - `window.createFormulas(containerSelector, includePercentage?)` — reads the formula input grid from the DOM and returns an array of formula objects: `{ colorantName: [ounces, drops] }` or `{ colorantName: [ounces, drops, percentage] }`

--- a/public/all-pages.css
+++ b/public/all-pages.css
@@ -1,147 +1,363 @@
-/* Global variable stuff */
-    :root {
-        /* --main-theme-color: #EA6200; */
-        --main-theme-color: #0081ea;
-    }
-    /* CSS related to all pages */
-    html {
-        background-color: gray;
-        font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-        font-size: medium;
-    }
+/* ── Variables ──────────────────────────────────────────────── */
+:root {
+    --main-theme-color: #F96302;
+    --nav-bg: #1a1a1a;
+    --nav-width: 200px;
+    --bg: #f5f5f5;
+}
 
-    body {
-        /* Centers the page */
-        margin-left: auto;
-        margin-right: auto;
-        max-width: 960px;
-    }
+/* ── Base ────────────────────────────────────────────────────── */
+html {
+    background-color: var(--bg);
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    font-size: medium;
+}
 
-    h1 {
-        color: black;
-        text-align: left;
-        font-size: 2rem;
-    }
+body {
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 960px;
+}
 
-    /* Color template */
-    #colorsContainer {
-        display: flex;
-        gap: 10px;
+h1 {
+    color: #1a1a1a;
+    text-align: left;
+    font-size: 1.6rem;
+    margin-top: 0;
+    margin-bottom: 16px;
+}
+
+h2 {
+    color: #1a1a1a;
+    font-size: 1.1rem;
+    margin-top: 0;
+    margin-bottom: 12px;
+}
+
+/* ── SPA shell layout ────────────────────────────────────────── */
+body:has(#shell) {
+    max-width: none;
+    margin: 0;
+}
+
+#shell {
+    display: flex;
+    min-height: 100vh;
+}
+
+/* ── Sidebar ─────────────────────────────────────────────────── */
+#sidebar {
+    width: var(--nav-width);
+    flex-shrink: 0;
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 100vh;
+    background: var(--nav-bg);
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+    z-index: 100;
+}
+
+#sidebar-header {
+    padding: 20px 16px 14px;
+    border-bottom: 1px solid #2a2a2a;
+}
+
+#sidebar-header h2 {
+    color: #F96302;
+    font-size: 1rem;
+    margin: 0 0 2px 0;
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+}
+
+#sidebar-header p {
+    color: #666;
+    font-size: 0.72rem;
+    margin: 0;
+}
+
+#sidebar nav {
+    flex: 1;
+    padding: 8px 0;
+    display: flex;
+    flex-direction: column;
+}
+
+.nav-section-label {
+    color: #555;
+    font-size: 0.68rem;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    padding: 14px 16px 4px;
+}
+
+.nav-divider {
+    border: none;
+    border-top: 1px solid #2a2a2a;
+    margin: 6px 0;
+}
+
+#sidebar .nav-link {
+    display: block;
+    color: #bbb;
+    text-decoration: none;
+    padding: 11px 20px;
+    font-size: 0.92rem;
+    transition: background 120ms, color 120ms;
+    border-left: 3px solid transparent;
+}
+
+#sidebar .nav-link:hover {
+    background: #2a2a2a;
+    color: white;
+}
+
+#sidebar .nav-link.active {
+    background: rgba(249, 99, 2, 0.12);
+    color: #F96302;
+    border-left-color: #F96302;
+}
+
+#sidebar .nav-link.external {
+    font-style: italic;
+    color: #666;
+    font-size: 0.82rem;
+}
+
+#sidebar .nav-link.external:hover {
+    color: #999;
+}
+
+/* ── Main content area ───────────────────────────────────────── */
+#main-content {
+    margin-left: var(--nav-width);
+    padding: 28px 32px;
+    background: var(--bg);
+    min-height: 100vh;
+    flex: 1;
+    box-sizing: border-box;
+}
+
+/* ── Views ───────────────────────────────────────────────────── */
+.view {
+    display: none;
+}
+
+.view.active {
+    display: block;
+}
+
+/* ── Cards ───────────────────────────────────────────────────── */
+.card {
+    background: white;
+    border-radius: 8px;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.10);
+    padding: 20px 24px;
+    margin-bottom: 16px;
+}
+
+/* ── Formula input grids (both ID and class selectors) ───────── */
+#colorsContainer,
+.colorsContainer {
+    display: flex;
+    gap: 10px;
+    width: 100%;
+}
+
+.colorGroup {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+}
+
+.formulaPaste {
+    border: 2px solid var(--main-theme-color);
+    box-sizing: border-box;
+    padding: 8px;
+    font-size: 0.85rem;
+    margin-bottom: 4px;
+    width: 100%;
+    border-radius: 3px;
+}
+
+#colorsContainer .color,
+.colorsContainer .color {
+    display: flex;
+    flex-direction: column;
+    padding: 3px 6px;
+}
+
+#colorsContainer .formulaRow,
+.colorsContainer .formulaRow {
+    display: flex;
+}
+
+#colorsContainer .formulaRow *,
+.colorsContainer .formulaRow * {
+    border: 2px solid var(--main-theme-color);
+    box-sizing: border-box;
+    margin: 0;
+    padding-top: 9px;
+    padding-bottom: 9px;
+    font-size: 0.95rem;
+    flex: 1;
+    max-width: 110px;
+}
+
+/* ── Size selectors (resizer) ────────────────────────────────── */
+#sizeSelectors {
+    display: flex;
+    gap: 8px;
+    padding: 8px 6px;
+    flex-wrap: wrap;
+}
+
+#sizeSelectors select {
+    border: 2px solid var(--main-theme-color);
+    padding: 8px;
+    font-size: 0.95rem;
+    box-sizing: border-box;
+}
+
+/* ── Results tables ──────────────────────────────────────────── */
+table, th, td {
+    background-color: white;
+    text-align: center;
+    color: black;
+    border: 2px solid var(--main-theme-color);
+    border-collapse: collapse;
+    font-weight: bold;
+}
+
+th {
+    background-color: var(--main-theme-color);
+    color: white;
+}
+
+td {
+    width: 40px;
+    background-color: #f0f0f0;
+}
+
+/* ── Buttons ─────────────────────────────────────────────────── */
+button, Button {
+    display: inline-block;
+    padding: 10px 20px;
+    background-color: var(--main-theme-color);
+    color: white;
+    border: none;
+    border-radius: 4px;
+    font-size: 0.95rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 120ms;
+    margin: 8px 0 4px 4px;
+}
+
+button:hover, Button:hover {
+    background-color: #d85400;
+}
+
+/* ── Old-page bottom nav (kept for scaler/combiner/resizer/differ.html) ── */
+body:not(:has(#shell)) nav {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+    overflow: auto;
+    white-space: nowrap;
+    background-color: #333;
+}
+
+li {
+    border-right: 1px solid gray;
+    display: inline-block;
+}
+
+li a {
+    display: block;
+    color: white;
+    text-align: center;
+    padding: 14px 16px;
+    text-decoration: none;
+    transition-duration: 100ms;
+}
+
+li a:hover {
+    background-color: #111;
+    color: white;
+}
+
+.active {
+    background-color: var(--main-theme-color);
+}
+
+.externalWebsite {
+    font-style: oblique;
+}
+
+/* ── Responsive: mobile bottom tab bar ──────────────────────── */
+@media (max-width: 640px) {
+    #sidebar {
         width: 100%;
-    }
-
-    .colorGroup {
-        display: flex;
-        flex-direction: column;
-    }
-
-    .formulaPaste {
-        border: 2px solid var(--main-theme-color);
-        box-sizing: border-box;
-        padding: 8px;
-        font-size: 0.9rem;
-        margin-bottom: 4px;
-    }
-
-    #colorsContainer .color {
-        display: flex;
-        flex-direction: column;
-        padding: 3px 10px;
-    }
-
-    #colorsContainer .formulaRow {
-        display: flex;
-    }
-
-    #colorsContainer .formulaRow * {
-        border: 2px solid var(--main-theme-color);
-        box-sizing: border-box;
-        margin: 0px;
-        padding-top: 10px;
-        padding-bottom: 10px;
-        font-size: 1rem;
-        flex: 1;
-        max-width: 120px;
-    }
-
-    #sizeSelectors {
-        display: table;
-        padding: 3px 10px;
-    }
-
-    /* Data tables */
-    table, th, td {
-        background-color: white;
-        text-align: center;
-        color: black;
-        border: 2px solid var(--main-theme-color);
-        border-collapse: collapse;
-        font-weight: bold;
-    }
-
-    th {
-        background-color: var(--main-theme-color);
-        color: white;
-    }
-
-    td {
-        width: 40px;
-        background-color: lightgray;
-    }
-
-    /* Buttons */
-    Button {
-        display: inline-table;
-        width: 24%;
-        min-width: min-content;
-        max-width: 100px;
-        padding-top: 10px;
-        padding-bottom: 10px;
-        background-color: var(--main-theme-color);
-        border: solid var(--main-theme-color);
-        transition-duration: 100ms;
-        margin-left: 1%;
-    }
-
-    /* Navigation bar */
-    nav {
+        height: auto;
         position: fixed;
+        top: auto;
         bottom: 0;
         left: 0;
         right: 0;
-        list-style-type: none;
-        margin: 0;
+        flex-direction: row;
+        overflow-x: auto;
+        overflow-y: hidden;
+        z-index: 100;
+    }
+
+    #sidebar-header {
+        display: none;
+    }
+
+    #sidebar nav {
+        flex-direction: row;
+        flex: 1;
         padding: 0;
-        overflow: auto;
-        white-space: nowrap;
-        background-color: #333;
+        overflow-x: auto;
     }
 
-    li {
-        border-right: 1px solid gray;
-        display: inline-block;
+    .nav-section-label,
+    .nav-divider {
+        display: none;
     }
 
-    .active {
-        background-color: var(--main-theme-color);
-        color: black;
-    }
-
-    li a {
-        display: block;
-        color: white;
+    #sidebar .nav-link {
+        flex: 1;
         text-align: center;
-        padding: 14px 16px;
-        text-decoration: none;
-        transition-duration: 100ms;
+        padding: 10px 6px;
+        font-size: 0.75rem;
+        border-left: none;
+        border-top: 3px solid transparent;
+        white-space: nowrap;
+        min-width: 56px;
     }
 
-    li a:hover {
-        background-color: #111;
-        color: white;
-        transition-duration: 100ms;
+    #sidebar .nav-link.active {
+        background: rgba(249, 99, 2, 0.15);
+        border-left-color: transparent;
+        border-top-color: #F96302;
     }
 
-    .externalWebsite {
-        font-style: oblique;
+    #sidebar .nav-link.external {
+        display: none;
     }
+
+    #main-content {
+        margin-left: 0;
+        padding: 16px;
+        padding-bottom: 68px;
+    }
+}

--- a/public/all-pages.css
+++ b/public/all-pages.css
@@ -3,7 +3,7 @@
     --main-theme-color: #F96302;
     --nav-bg: #1a1a1a;
     --nav-width: 200px;
-    --bg: #f5f5f5;
+    --bg: #dcdcdc;
 }
 
 /* ── Base ────────────────────────────────────────────────────── */
@@ -153,10 +153,10 @@ body:has(#shell) {
 /* ── Cards ───────────────────────────────────────────────────── */
 .card {
     background: white;
-    border-radius: 8px;
-    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.10);
-    padding: 20px 24px;
-    margin-bottom: 16px;
+    border-radius: 16px;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.10), 0 1px 4px rgba(0, 0, 0, 0.06);
+    padding: 24px 28px;
+    margin-bottom: 20px;
 }
 
 /* ── Formula input grids (both ID and class selectors) ───────── */
@@ -176,11 +176,11 @@ body:has(#shell) {
 .formulaPaste {
     border: 2px solid var(--main-theme-color);
     box-sizing: border-box;
-    padding: 8px;
+    padding: 8px 10px;
     font-size: 0.85rem;
-    margin-bottom: 4px;
+    margin-bottom: 6px;
     width: 100%;
-    border-radius: 3px;
+    border-radius: 8px;
 }
 
 #colorsContainer .color,
@@ -245,21 +245,24 @@ td {
 /* ── Buttons ─────────────────────────────────────────────────── */
 button, Button {
     display: inline-block;
-    padding: 10px 20px;
+    padding: 10px 22px;
     background-color: var(--main-theme-color);
     color: white;
     border: none;
-    border-radius: 4px;
+    border-radius: 8px;
     font-size: 0.95rem;
     font-weight: 600;
     cursor: pointer;
-    transition: background 120ms;
-    margin: 8px 0 4px 4px;
+    transition: background 120ms, box-shadow 120ms;
+    margin: 10px 0 4px 4px;
+    box-shadow: 0 2px 6px rgba(249, 99, 2, 0.35);
 }
 
 button:hover, Button:hover {
     background-color: #d85400;
+    box-shadow: 0 4px 12px rgba(249, 99, 2, 0.45);
 }
+
 
 /* ── Old-page bottom nav (kept for scaler/combiner/resizer/differ.html) ── */
 body:not(:has(#shell)) nav {

--- a/public/common.js
+++ b/public/common.js
@@ -7,6 +7,7 @@
 
   // Add shared metadata, icons, stylesheet, and manifest
   function addHeadElements() {
+    if(document.querySelector('link[href="all-pages.css"]')) return;
     const head = document.head;
     const tags = [
       {tag:"link", rel:"stylesheet", href:"all-pages.css"},
@@ -38,6 +39,7 @@
 
   // Build navigation bar
   function buildNav(){
+    if(document.querySelector('nav')) return;
     const nav = document.createElement('nav');
     const links = [
       {href:'scaler.html', text:'Scale'},
@@ -129,7 +131,7 @@
   }
 
   function buildPasteInputs(){
-    document.querySelectorAll('#colorsContainer .color').forEach(colorDiv => {
+    document.querySelectorAll('#colorsContainer .color, .colorsContainer .color').forEach(colorDiv => {
       const wrapper = document.createElement('div');
       wrapper.className = 'colorGroup';
       colorDiv.parentNode.insertBefore(wrapper, colorDiv);

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,482 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <meta name="description" content="Tools for the paint desk.">
+    <meta name="theme-color" content="#F96302">
+    <title>Paint Tools</title>
+    <link rel="stylesheet" href="all-pages.css">
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+    <link rel="manifest" href="manifest.json">
+    <script src="common.js"></script>
+</head>
+<body>
+<div id="shell">
+
+    <!-- ── Sidebar ──────────────────────────────────────────── -->
+    <div id="sidebar">
+        <div id="sidebar-header">
+            <h2>Paint Tools</h2>
+            <p>Paint desk utilities</p>
+        </div>
+        <nav>
+            <div class="nav-section-label">Tools</div>
+            <a class="nav-link" data-view="scaler"   href="#scaler">Scale</a>
+            <a class="nav-link" data-view="combiner" href="#combiner">Combine</a>
+            <a class="nav-link" data-view="resizer"  href="#resizer">Resize</a>
+            <a class="nav-link" data-view="differ"   href="#differ">Differ</a>
+            <hr class="nav-divider">
+            <div class="nav-section-label">External</div>
+            <a class="nav-link external" href="https://encycolorpedia.com/" target="_blank" rel="noopener">Encycolorpedia</a>
+            <a class="nav-link external" href="https://www.easyrgb.com/en/match.php" target="_blank" rel="noopener">EasyRGB</a>
+        </nav>
+    </div>
+
+    <!-- ── Main content ─────────────────────────────────────── -->
+    <main id="main-content">
+
+        <!-- ── Scaler ──────────────────────────────────────── -->
+        <section class="view active" id="view-scaler">
+            <div class="card">
+                <h1>Color Scaler</h1>
+                <div class="colorsContainer" id="scaler-colorsContainer">
+                    <div class="color">
+                        <div class="formulaRow">
+                            <select class="selectedColor"></select>
+                            <input class="ounces" placeholder="Oz" type="number" min="0" max="100">
+                            <input class="drops" placeholder="Drops" type="number" min="0" max="383">
+                            <input class="percentage" placeholder="%" type="number" min="-1000" max="1000">
+                        </div>
+                        <div class="formulaRow">
+                            <select class="selectedColor"></select>
+                            <input class="ounces" placeholder="Oz" type="number" min="0" max="100">
+                            <input class="drops" placeholder="Drops" type="number" min="0" max="383">
+                            <input class="percentage" placeholder="%" type="number" min="-1000" max="1000">
+                        </div>
+                        <div class="formulaRow">
+                            <select class="selectedColor"></select>
+                            <input class="ounces" placeholder="Oz" type="number" min="0" max="100">
+                            <input class="drops" placeholder="Drops" type="number" min="0" max="383">
+                            <input class="percentage" placeholder="%" type="number" min="-1000" max="1000">
+                        </div>
+                        <div class="formulaRow">
+                            <select class="selectedColor"></select>
+                            <input class="ounces" placeholder="Oz" type="number" min="0" max="100">
+                            <input class="drops" placeholder="Drops" type="number" min="0" max="383">
+                            <input class="percentage" placeholder="%" type="number" min="-1000" max="1000">
+                        </div>
+                        <div class="formulaRow">
+                            <select class="selectedColor"></select>
+                            <input class="ounces" placeholder="Oz" type="number" min="0" max="100">
+                            <input class="drops" placeholder="Drops" type="number" min="0" max="383">
+                            <input class="percentage" placeholder="%" type="number" min="-1000" max="1000">
+                        </div>
+                    </div>
+                </div>
+                <button id="scaleButton">Scale</button>
+            </div>
+            <div class="card">
+                <h2>Results</h2>
+                <table id="scaler-resultsTable">
+                    <tr id="scaler-resultColorNames"></tr>
+                    <tr id="scaler-resultOunces"></tr>
+                    <tr id="scaler-resultDrops"></tr>
+                </table>
+            </div>
+        </section>
+
+        <!-- ── Combiner ─────────────────────────────────────── -->
+        <section class="view" id="view-combiner">
+            <div class="card">
+                <h1>Color Combiner</h1>
+                <div class="colorsContainer" id="combiner-colorsContainer">
+                    <div class="color">
+                        <div class="formulaRow">
+                            <select class="selectedColor"></select>
+                            <input class="ounces" placeholder="Oz" type="number" min="0" max="100">
+                            <input class="drops" placeholder="Drops" type="number" min="0" max="383">
+                        </div>
+                        <div class="formulaRow">
+                            <select class="selectedColor"></select>
+                            <input class="ounces" placeholder="Oz" type="number" min="0" max="100">
+                            <input class="drops" placeholder="Drops" type="number" min="0" max="383">
+                        </div>
+                        <div class="formulaRow">
+                            <select class="selectedColor"></select>
+                            <input class="ounces" placeholder="Oz" type="number" min="0" max="100">
+                            <input class="drops" placeholder="Drops" type="number" min="0" max="383">
+                        </div>
+                        <div class="formulaRow">
+                            <select class="selectedColor"></select>
+                            <input class="ounces" placeholder="Oz" type="number" min="0" max="100">
+                            <input class="drops" placeholder="Drops" type="number" min="0" max="383">
+                        </div>
+                        <div class="formulaRow">
+                            <select class="selectedColor"></select>
+                            <input class="ounces" placeholder="Oz" type="number" min="0" max="100">
+                            <input class="drops" placeholder="Drops" type="number" min="0" max="383">
+                        </div>
+                    </div>
+                    <div class="color">
+                        <div class="formulaRow">
+                            <select class="selectedColor"></select>
+                            <input class="ounces" placeholder="Oz" type="number" min="0" max="100">
+                            <input class="drops" placeholder="Drops" type="number" min="0" max="383">
+                        </div>
+                        <div class="formulaRow">
+                            <select class="selectedColor"></select>
+                            <input class="ounces" placeholder="Oz" type="number" min="0" max="100">
+                            <input class="drops" placeholder="Drops" type="number" min="0" max="383">
+                        </div>
+                        <div class="formulaRow">
+                            <select class="selectedColor"></select>
+                            <input class="ounces" placeholder="Oz" type="number" min="0" max="100">
+                            <input class="drops" placeholder="Drops" type="number" min="0" max="383">
+                        </div>
+                        <div class="formulaRow">
+                            <select class="selectedColor"></select>
+                            <input class="ounces" placeholder="Oz" type="number" min="0" max="100">
+                            <input class="drops" placeholder="Drops" type="number" min="0" max="383">
+                        </div>
+                        <div class="formulaRow">
+                            <select class="selectedColor"></select>
+                            <input class="ounces" placeholder="Oz" type="number" min="0" max="100">
+                            <input class="drops" placeholder="Drops" type="number" min="0" max="383">
+                        </div>
+                    </div>
+                </div>
+                <button id="combineButton">Combine</button>
+            </div>
+            <div class="card">
+                <h2>Results</h2>
+                <table id="combiner-resultsTable">
+                    <tr id="combiner-resultColorNames"></tr>
+                    <tr id="combiner-resultOunces"></tr>
+                    <tr id="combiner-resultDrops"></tr>
+                </table>
+            </div>
+        </section>
+
+        <!-- ── Resizer ──────────────────────────────────────── -->
+        <section class="view" id="view-resizer">
+            <div class="card">
+                <h1>Formula Resizer</h1>
+                <div class="colorsContainer" id="resizer-colorsContainer">
+                    <div class="color">
+                        <div class="formulaRow">
+                            <select class="selectedColor"></select>
+                            <input class="ounces" placeholder="Oz" type="number" min="0" max="100">
+                            <input class="drops" placeholder="Drops" type="number" min="0" max="383">
+                        </div>
+                        <div class="formulaRow">
+                            <select class="selectedColor"></select>
+                            <input class="ounces" placeholder="Oz" type="number" min="0" max="100">
+                            <input class="drops" placeholder="Drops" type="number" min="0" max="383">
+                        </div>
+                        <div class="formulaRow">
+                            <select class="selectedColor"></select>
+                            <input class="ounces" placeholder="Oz" type="number" min="0" max="100">
+                            <input class="drops" placeholder="Drops" type="number" min="0" max="383">
+                        </div>
+                        <div class="formulaRow">
+                            <select class="selectedColor"></select>
+                            <input class="ounces" placeholder="Oz" type="number" min="0" max="100">
+                            <input class="drops" placeholder="Drops" type="number" min="0" max="383">
+                        </div>
+                        <div class="formulaRow">
+                            <select class="selectedColor"></select>
+                            <input class="ounces" placeholder="Oz" type="number" min="0" max="100">
+                            <input class="drops" placeholder="Drops" type="number" min="0" max="383">
+                        </div>
+                    </div>
+                </div>
+                <div id="sizeSelectors">
+                    <select id="resizer-originalSize">
+                        <option value="8">8 oz</option>
+                        <option value="32">Quart</option>
+                        <option value="128">Gallon</option>
+                        <option value="640">5 Gallon</option>
+                    </select>
+                    <select id="resizer-newSize">
+                        <option value="8">8 oz</option>
+                        <option value="32">Quart</option>
+                        <option value="128">Gallon</option>
+                        <option value="640">5 Gallon</option>
+                    </select>
+                </div>
+                <button id="resizeButton">Resize</button>
+            </div>
+            <div class="card">
+                <h2>Results</h2>
+                <table id="resizer-resultsTable">
+                    <tr id="resizer-resultColorNames"></tr>
+                    <tr id="resizer-resultOunces"></tr>
+                    <tr id="resizer-resultDrops"></tr>
+                </table>
+            </div>
+        </section>
+
+        <!-- ── Differ ───────────────────────────────────────── -->
+        <section class="view" id="view-differ">
+            <div class="card">
+                <h1>Formula Differ</h1>
+                <div class="colorsContainer" id="differ-colorsContainer">
+                    <div class="color">
+                        <div class="formulaRow">
+                            <select class="selectedColor"></select>
+                            <input class="ounces" placeholder="Oz" type="number" min="0" max="100">
+                            <input class="drops" placeholder="Drops" type="number" min="0" max="383">
+                        </div>
+                        <div class="formulaRow">
+                            <select class="selectedColor"></select>
+                            <input class="ounces" placeholder="Oz" type="number" min="0" max="100">
+                            <input class="drops" placeholder="Drops" type="number" min="0" max="383">
+                        </div>
+                        <div class="formulaRow">
+                            <select class="selectedColor"></select>
+                            <input class="ounces" placeholder="Oz" type="number" min="0" max="100">
+                            <input class="drops" placeholder="Drops" type="number" min="0" max="383">
+                        </div>
+                        <div class="formulaRow">
+                            <select class="selectedColor"></select>
+                            <input class="ounces" placeholder="Oz" type="number" min="0" max="100">
+                            <input class="drops" placeholder="Drops" type="number" min="0" max="383">
+                        </div>
+                        <div class="formulaRow">
+                            <select class="selectedColor"></select>
+                            <input class="ounces" placeholder="Oz" type="number" min="0" max="100">
+                            <input class="drops" placeholder="Drops" type="number" min="0" max="383">
+                        </div>
+                    </div>
+                    <div class="color">
+                        <div class="formulaRow">
+                            <select class="selectedColor"></select>
+                            <input class="ounces" placeholder="Oz" type="number" min="0" max="100">
+                            <input class="drops" placeholder="Drops" type="number" min="0" max="383">
+                        </div>
+                        <div class="formulaRow">
+                            <select class="selectedColor"></select>
+                            <input class="ounces" placeholder="Oz" type="number" min="0" max="100">
+                            <input class="drops" placeholder="Drops" type="number" min="0" max="383">
+                        </div>
+                        <div class="formulaRow">
+                            <select class="selectedColor"></select>
+                            <input class="ounces" placeholder="Oz" type="number" min="0" max="100">
+                            <input class="drops" placeholder="Drops" type="number" min="0" max="383">
+                        </div>
+                        <div class="formulaRow">
+                            <select class="selectedColor"></select>
+                            <input class="ounces" placeholder="Oz" type="number" min="0" max="100">
+                            <input class="drops" placeholder="Drops" type="number" min="0" max="383">
+                        </div>
+                        <div class="formulaRow">
+                            <select class="selectedColor"></select>
+                            <input class="ounces" placeholder="Oz" type="number" min="0" max="100">
+                            <input class="drops" placeholder="Drops" type="number" min="0" max="383">
+                        </div>
+                    </div>
+                </div>
+                <button id="diffButton">Diff</button>
+            </div>
+            <div class="card">
+                <h2>Results</h2>
+                <table id="differ-resultsTable">
+                    <tr id="differ-resultColorNames"></tr>
+                    <tr id="differ-resultLabel"></tr>
+                    <tr id="differ-resultOunces"></tr>
+                    <tr id="differ-resultDrops"></tr>
+                </table>
+            </div>
+        </section>
+
+    </main>
+</div>
+
+<script>
+    // ── View switching ───────────────────────────────────────────
+    const VIEWS = ['scaler', 'combiner', 'resizer', 'differ'];
+
+    function showView(name) {
+        if (!VIEWS.includes(name)) name = 'scaler';
+        document.querySelectorAll('.view').forEach(v => v.classList.remove('active'));
+        document.querySelectorAll('.nav-link[data-view]').forEach(a => a.classList.remove('active'));
+        document.getElementById('view-' + name).classList.add('active');
+        const link = document.querySelector('.nav-link[data-view="' + name + '"]');
+        if (link) link.classList.add('active');
+        history.replaceState(null, '', '#' + name);
+    }
+
+    document.querySelectorAll('.nav-link[data-view]').forEach(a => {
+        a.addEventListener('click', e => {
+            e.preventDefault();
+            showView(a.dataset.view);
+        });
+    });
+
+    window.addEventListener('hashchange', () => {
+        showView(location.hash.slice(1));
+    });
+
+    // ── Tool logic ───────────────────────────────────────────────
+    document.addEventListener('DOMContentLoaded', () => {
+        showView(location.hash.slice(1) || 'scaler');
+
+        // ── Shared display helper ────────────────────────────────
+        function makeDisplay(namesEl, ouncesEl, dropsEl) {
+            return function(formula) {
+                [namesEl, ouncesEl, dropsEl].forEach(el => el.innerHTML = '');
+                for (const colorant in formula) {
+                    if (colorant === 'Select color') continue;
+                    const th = document.createElement('th');
+                    th.textContent = colorant;
+                    namesEl.appendChild(th);
+                    const oz = document.createElement('td');
+                    oz.textContent = formula[colorant][0];
+                    ouncesEl.appendChild(oz);
+                    const dr = document.createElement('td');
+                    dr.textContent = formula[colorant][1];
+                    dropsEl.appendChild(dr);
+                }
+            };
+        }
+
+        // ── Scaler ───────────────────────────────────────────────
+        const displayScaler = makeDisplay(
+            document.getElementById('scaler-resultColorNames'),
+            document.getElementById('scaler-resultOunces'),
+            document.getElementById('scaler-resultDrops')
+        );
+
+        function scale() {
+            const formula = createFormulas('#scaler-colorsContainer', true)[0];
+            const out = {};
+            for (const colorant in formula) {
+                if (colorant === 'Select color') continue;
+                const totalDrops = ((formula[colorant][0] * 384) + formula[colorant][1]) * (formula[colorant][2] / 100);
+                out[colorant] = [Math.floor(totalDrops / 384), Math.floor((totalDrops % 384) * 100) / 100];
+            }
+            displayScaler(out);
+        }
+
+        const scalerContainer = document.getElementById('scaler-colorsContainer');
+        document.getElementById('scaleButton').addEventListener('click', scale);
+        scalerContainer.addEventListener('input', scale);
+        scalerContainer.addEventListener('change', scale);
+
+        // ── Combiner ─────────────────────────────────────────────
+        const displayCombiner = makeDisplay(
+            document.getElementById('combiner-resultColorNames'),
+            document.getElementById('combiner-resultOunces'),
+            document.getElementById('combiner-resultDrops')
+        );
+
+        function combineColors(A, B) {
+            const out = {};
+            for (const c in A) {
+                const t = ((A[c][0] * 384) + A[c][1]) / 2;
+                out[c] = [Math.floor(t / 384), Math.round((t % 384) * 2) / 2];
+            }
+            for (const c in B) {
+                const t = ((B[c][0] * 384) + B[c][1]) / 2;
+                const oz = Math.floor(t / 384), dr = Math.round((t % 384) * 2) / 2;
+                if (c in out) {
+                    out[c][0] += oz;
+                    out[c][1] += dr;
+                    if (out[c][1] > 383) { out[c][0]++; out[c][1] -= 384; }
+                } else {
+                    out[c] = [oz, dr];
+                }
+            }
+            return out;
+        }
+
+        function combine() {
+            const colors = createFormulas('#combiner-colorsContainer');
+            displayCombiner(combineColors(colors[0], colors[1]));
+        }
+
+        const combinerContainer = document.getElementById('combiner-colorsContainer');
+        document.getElementById('combineButton').addEventListener('click', combine);
+        combinerContainer.addEventListener('input', combine);
+        combinerContainer.addEventListener('change', combine);
+
+        // ── Resizer ──────────────────────────────────────────────
+        const displayResizer = makeDisplay(
+            document.getElementById('resizer-resultColorNames'),
+            document.getElementById('resizer-resultOunces'),
+            document.getElementById('resizer-resultDrops')
+        );
+
+        const resizerOrigSize = document.getElementById('resizer-originalSize');
+        const resizerNewSize  = document.getElementById('resizer-newSize');
+
+        function resize() {
+            const formula = createFormulas('#resizer-colorsContainer')[0];
+            const factor = +resizerNewSize.value / +resizerOrigSize.value;
+            const out = {};
+            for (const colorant in formula) {
+                if (colorant === 'Select color') continue;
+                const resized = ((formula[colorant][0] * 384) + formula[colorant][1]) * factor;
+                out[colorant] = [Math.floor(resized / 384), Math.floor((resized % 384) * 100) / 100];
+            }
+            displayResizer(out);
+        }
+
+        const resizerContainer = document.getElementById('resizer-colorsContainer');
+        document.getElementById('resizeButton').addEventListener('click', resize);
+        resizerContainer.addEventListener('input', resize);
+        resizerContainer.addEventListener('change', resize);
+        resizerOrigSize.addEventListener('change', resize);
+        resizerNewSize.addEventListener('change', resize);
+
+        // ── Differ ───────────────────────────────────────────────
+        const differ_names  = document.getElementById('differ-resultColorNames');
+        const differ_label  = document.getElementById('differ-resultLabel');
+        const differ_ounces = document.getElementById('differ-resultOunces');
+        const differ_drops  = document.getElementById('differ-resultDrops');
+
+        function runDiff() {
+            const formulas = createFormulas('#differ-colorsContainer');
+            const A = formulas[0], B = formulas[1];
+            const shared = {}, onlyA = {}, onlyB = {};
+            const all = new Set([
+                ...Object.keys(A).filter(c => c !== 'Select color'),
+                ...Object.keys(B).filter(c => c !== 'Select color')
+            ]);
+            all.forEach(c => {
+                if (c in A && c in B) {
+                    const diff = (A[c][0] * 384 + A[c][1]) - (B[c][0] * 384 + B[c][1]);
+                    shared[c] = [Math.trunc(diff / 384), diff % 384];
+                } else if (c in A) {
+                    onlyA[c] = A[c];
+                } else {
+                    onlyB[c] = B[c];
+                }
+            });
+            displayDiffs(shared, onlyA, onlyB);
+        }
+
+        function displayDiffs(shared, onlyA, onlyB) {
+            [differ_names, differ_label, differ_ounces, differ_drops].forEach(el => el.innerHTML = '');
+            function addEntry(c, oz, dr, label) {
+                const th = document.createElement('th'); th.textContent = c; differ_names.appendChild(th);
+                const lb = document.createElement('td'); lb.textContent = label; differ_label.appendChild(lb);
+                const ozTd = document.createElement('td'); ozTd.textContent = (oz > 0 ? '+' : '') + oz; differ_ounces.appendChild(ozTd);
+                const drTd = document.createElement('td'); drTd.textContent = (dr > 0 ? '+' : '') + dr; differ_drops.appendChild(drTd);
+            }
+            for (const c in shared) addEntry(c, shared[c][0], shared[c][1], '');
+            for (const c in onlyA)  addEntry(c, onlyA[c][0],  onlyA[c][1],  'A only');
+            for (const c in onlyB)  addEntry(c, onlyB[c][0],  onlyB[c][1],  'B only');
+        }
+
+        const differContainer = document.getElementById('differ-colorsContainer');
+        document.getElementById('diffButton').addEventListener('click', runDiff);
+        differContainer.addEventListener('input', runDiff);
+        differContainer.addEventListener('change', runDiff);
+    });
+</script>
+</body>
+</html>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -23,8 +23,8 @@
             "sizes": "512x512"
         }
     ],
-    "start_url": "scaler.html",
-    "background_color": "#888888",
+    "start_url": "index.html",
+    "background_color": "#1a1a1a",
     "display": "standalone",
-    "theme_color": "#888888"
+    "theme_color": "#F96302"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,7 @@
-const version = "0.1.3"
+const version = "0.1.4"
 
 const assets = [
+    "/index.html",
     "/all-pages.css",
     "/common.js",
     "/scaler.html",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const version = "0.1.4"
+const version = "0.1.5"
 
 const assets = [
     "/index.html",


### PR DESCRIPTION
## Summary

- **`index.html` (new)** — single-page app entry point. All four tools (Scale, Combine, Resize, Differ) load at once as `<section class="view">` elements toggled by a CSS class. No full page reloads when switching tools. Hash-based routing (`#scaler`, `#combiner`, etc.) preserves deep links and browser refresh.
- **Home Depot orange theme** — `#F96302` replaces the old blue throughout: borders, table headers, buttons, active nav highlight, sidebar brand.
- **Left sidebar nav** — fixed 200 px sidebar with tool links and external links. On mobile (≤ 640 px) it reflows into a fixed bottom tab bar; external links are hidden at that breakpoint.
- **Card layout** — each tool's input and results sections sit in white rounded cards on a light gray background.
- **`common.js` guards** — `addHeadElements()` skips if the stylesheet link is already present; `buildNav()` skips if a `<nav>` already exists. The old individual pages (scaler.html etc.) continue to work unchanged.
- **`manifest.json`** — `start_url` updated to `index.html`; PWA theme/background colors updated to match new palette.
- **`sw.js`** — `index.html` added to cache; version bumped to `0.1.4`.

## Test plan

- [ ] Open `index.html` — Scaler view visible, orange sidebar on the left
- [ ] Click each sidebar link — view switches without page reload, URL hash and active highlight update
- [ ] Refresh on `index.html#differ` — Differ view loads directly
- [ ] Paste a formula string into any view's paste input — grid fills and result updates live
- [ ] Resize browser to < 640 px — sidebar becomes a bottom tab bar; external links disappear
- [ ] Open `scaler.html` directly — still works with its own bottom nav bar, no duplicate nav

https://claude.ai/code/session_01FfRHoLZ3YqBstHyU8HWqVS

---
_Generated by [Claude Code](https://claude.ai/code/session_01FfRHoLZ3YqBstHyU8HWqVS)_